### PR TITLE
Bubble up ImportErrors

### DIFF
--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -14,7 +14,7 @@ import jinja2
 VERSION = (0, 3)
 __version__ = '.'.join(map(str, VERSION))
 
-log = logging.getLogger('z.jingo')
+log = logging.getLogger('jingo')
 
 
 _helpers_loaded = False


### PR DESCRIPTION
Jingo was silently swallowing all `ImportError`s, so even if an app had a `helpers` module it might not load, and you wouldn't know that until you tried to use its helpers.

This branch ignores missing `helpers` modules, or apps that mess with their `__path__`, but if there is a `helpers` module and it causes an `ImportError`, it bubbles that up so it's clear what happened.

Idea stolen from [Gargoyle](https://github.com/disqus/gargoyle/blob/master/gargoyle/__init__.py#L27).
