### PR TITLE
Nulltrans

### DIFF
--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -56,8 +56,6 @@ def get_env():
         opts.update(config)
 
     e = Environment(**opts)
-    # TODO: use real translations
-    e.install_null_translations()
     return e
 
 


### PR DESCRIPTION
OK, as far as I can tell, `install_null_translations` doesn't do anything. Removing the line doesn't affect the kitsune test suite and I can still use the site in all the locales, so...

Removing this line makes it possible to use jingo in non-localized webapps without the overhead of the i18n/l10n subsystem.
