### PR TITLE
Using Django's Template Loader mechanism

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,9 @@
 .. _jingo:
 .. module:: jingo
 
-A page about Jingo.
-===================
+Jingo
+=====
+
 
 Jingo is an adapter for using
 `Jinja2 <http://jinja.pocoo.org/2/documentation/>`_ templates within Django.
@@ -26,20 +27,14 @@ or ::
     def JINJA_CONFIG():
         return {'the_answer': 41 + 1}
 
+You'll want to use jingo's template loader::
 
-Rendering
----------
+    TEMPLATE_LOADERS = (
+        'jingo.Loader',
+    )
 
-At this point, Jingo only provides two shortcuts for rendering templates.
-
-.. autofunction:: jingo.render
-
-    The basic usage is to pass an ``HttpRequest`` and a template name.  All the
-    processors in ``settings.CONTEXT_PROCESSORS`` will be applied to the
-    context, just like when you use a ``RequestContext`` in Django.  Any extra
-    keyword arguments are passed directly to ``http.HttpResponse``.
-
-.. autofunction:: jingo.views.direct_to_template
+This will let you use ``django.shortcuts.render`` or
+``django.shortcuts.render_to_response``.
 
 
 Template Helpers

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -6,6 +6,7 @@ import logging
 from django import http
 from django.conf import settings
 from django.template.context import get_standard_processors
+from django.template.loader import BaseLoader
 from django.utils.importlib import import_module
 from django.utils.translation import trans_real
 
@@ -151,3 +152,23 @@ class Register(object):
 
 env = get_env()
 register = Register(env)
+
+
+class Template(object):
+    def __init__(self, template):
+        self.template = template
+
+    def render(self, context):
+        # flatten the Django Context into a single dictionary.
+        context_dict = {}
+        for d in context.dicts:
+            context_dict.update(d)
+        return self.template.render(context_dict)
+
+
+class Loader(BaseLoader):
+    is_usable = True
+
+    def load_template(self, template_name, template_dirs=None):
+        template = env.get_template(template_name)
+        return Template(template), template.filename


### PR DESCRIPTION
James Bennet (ubernostrum) pointed out that we could use Django's template loaders and then not lose functionality of render_to_response or django.shortcuts.render.

It just so happens I need that functionality (when writing libraries for django you don't want to have to guess at their templater, just use django abstracted methods).

I think this obsolete's jingo.render, but I think jingo.render can do a few more tricks... so I'm open to changing this a lot.  I updated docs too, and decided people can just follow the standard django docs for rendering.
