### PR TITLE
Fixed compatibility error when the jingo2.ext.i18n extension is not loaded. 

### DIFF
--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -59,7 +59,8 @@ def get_env():
     e = Environment(**opts)
     # Install null translations since gettext isn't always loaded up during
     # testing.
-    e.install_null_translations()
+    if 'jinja2.ext.i18n' in e.extensions:
+        e.install_null_translations()
     return e
 
 


### PR DESCRIPTION
If you used the JINJA_CONFIG django setting to adjust your jinja2 extensions and omit i18n, this would cause an exception to be thrown on all requests. 

This simply checks to see if i18n extension is enabled before trying to load translations.

HOW TO REPLICATE:
  use jingo with JINJA_CONFIG = { 'extensions': [] } and you will get an exception: 

```
  'Environment' object has no attribute 'install_null_translations'
```
