### PR TITLE
Adding url() helper that wraps the django.core.urlresolvers.reverse() function. 

### DIFF
--- a/fake_settings.py
+++ b/fake_settings.py
@@ -5,7 +5,7 @@ path = lambda *a: os.path.join(ROOT, *a)
 ROOT = os.path.dirname(os.path.abspath(__file__))
 INSTALLED_APPS = (
     'jingo.tests.jinja_app',
-    'jingo.tests.django_app'
+    'jingo.tests.django_app',
 )
 TEMPLATE_LOADERS = (
     'jingo.Loader',
@@ -14,3 +14,4 @@ TEMPLATE_LOADERS = (
 )
 TEMPLATE_DIRS = (path('jingo/tests/templates'),)
 JINGO_EXCLUDE_APPS = ('django_app',)
+ROOT_URLCONF = 'jingo.tests.urls'

--- a/jingo/helpers.py
+++ b/jingo/helpers.py
@@ -1,6 +1,7 @@
 from django.utils.translation import ugettext as _
 from django.template.defaulttags import CsrfTokenNode
 from django.utils.encoding import smart_unicode
+from django.core.urlresolvers import reverse
 
 import jinja2
 
@@ -73,3 +74,9 @@ def field_attrs(field_inst, **kwargs):
     """Adds html attributes to django form fields"""
     field_inst.field.widget.attrs.update(kwargs)
     return field_inst
+
+
+@register.function
+def url(viewname, *args, **kwargs):
+    """Return URL using django's ``reverse()`` function."""
+    return reverse(viewname, args=args, kwargs=kwargs)

--- a/jingo/tests/test_helpers.py
+++ b/jingo/tests/test_helpers.py
@@ -119,3 +119,11 @@ def test_field_attrs():
     s = render('{{ field|field_attrs(class="bar",name="baz") }}',
                {'field': f})
     eq_(s, '<input class="bar" name="baz" />')
+
+
+def test_url():
+    # urls defined in jingo/tests/urls.py
+    s = render('{{ url("url-args", 1, "foo") }}')
+    eq_(s, "/url/1/foo/")
+    s = render('{{ url("url-kwargs", word="bar", num=1) }}')
+    eq_(s, "/url/1/bar/")

--- a/jingo/tests/urls.py
+++ b/jingo/tests/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls.defaults import patterns
+
+urlpatterns = patterns('',
+    (r'^url/(\d+)/(\w+)/$', lambda r: None, {}, "url-args"),
+    (r'^url/(?P<num>\d+)/(?P<word>\w+)/$', lambda r: None, {}, "url-kwargs"),
+)


### PR DESCRIPTION
This also cleans up the previously requested change to be PEP8 compliant.

I tried to revert old commits and create one clean commit that can be merged in.
The commit '2509efec' contains all the changes/tests that represent the feature, but github pull requests apparently do not let you cherry-pick out particular commits; it wants to merge the entire branch.

Hopefully these 5 commits can be squashed into one commit when merged in; if this is not the case, it would be possible for us to do a non-fast-forward merge on concentricsky/jingo@master if needed to discard the extra revert commits. 
