### PR TITLE
Remove jingo.views and tests. Fix #2.

### DIFF
--- a/jingo/tests/test_views.py
+++ b/jingo/tests/test_views.py
@@ -1,17 +1,18 @@
 from django.utils import translation
-from mock import Mock, patch, sentinel
+from django.views.generic.simple import direct_to_template
 
+from mock import patch, sentinel
 from nose.tools import eq_
 
-import jingo.views
-from jingo import get_env
+from jingo import get_env, render_to_string
 
 
 @patch('jingo.render')
 def test_direct_to_template(mock_render):
-    request = sentinel.request
-    jingo.views.direct_to_template(request, 'base.html', x=1)
-    mock_render.assert_called_with(request, 'base.html', {'x': 1})
+    response = direct_to_template(sentinel.request,
+                                  'jinja_app/test_nonoverride.html',
+                                  {'x': 1})
+    eq_('HELLO', response.content)
 
 
 def test_template_substitution_crash():
@@ -22,5 +23,5 @@ def test_template_substitution_crash():
     # The localized string has the wrong variable name in it
     s = '{% trans string="heart" %}Broken {{ string }}{% endtrans %}'
     template = env.from_string(s)
-    rendered = jingo.render_to_string(Mock(), template, {})
+    rendered = render_to_string(sentinel.request, template, {})
     eq_(rendered, 'Broken heart')

--- a/jingo/views.py
+++ b/jingo/views.py
@@ -1,5 +1,0 @@
-import jingo
-
-
-def direct_to_template(request, template, **kwargs):
-    return jingo.render(request, template, kwargs)


### PR DESCRIPTION
With the changes since #2 was filed, it's no longer necessary to have
jingo.views.direct_to_template at all. Django's direct_to_template view
works just fine with jingo.Loader.

I cleaned up some tests, but jingo.render_to_string is still a different
function than django.template.loader.render_to_string, so I wasn't able
to drop that.
