### PR TITLE
Fix datetime formatting on windows 

### DIFF
--- a/jingo/helpers.py
+++ b/jingo/helpers.py
@@ -4,6 +4,7 @@ from django.utils.encoding import smart_unicode
 from django.core.urlresolvers import reverse
 
 import jinja2
+import platform
 
 from jingo import register
 
@@ -53,7 +54,10 @@ def nl2br(string):
 def datetime(t, fmt=None):
     """Call ``datetime.strftime`` with the given format string."""
     if fmt is None:
-        fmt = _('%B %e, %Y')
+        if platform.system() == "Windows":
+            fmt = _('%B %d, %Y')
+        else:
+            fmt = _('%B %e, %Y')
     return smart_unicode(t.strftime(fmt.encode('utf-8'))) if t else u''
 
 


### PR DESCRIPTION
Done by replacing %e with %d for windows platform, this is the least complicated method of doing things but will cause
inconsistent behavior across systems.

Anyone has another suggestion? (This is discuessed in issue #23)