### PR TITLE
"render" shortcut doc fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ your view the same way you'd render Django templates::
     def MyView(request):
         # TODO: Do something.
         context = dict(user_ids=[1, 2, 3, 4])
-        render('users/search.html', context)
+        render(request, 'users/search.html', context)
 
 ..note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ your view the same way you'd render Django templates::
     def MyView(request):
         # TODO: Do something.
         context = dict(user_ids=[1, 2, 3, 4])
-        render('users/search.html', context)
+        render(request, 'users/search.html', context)
 
 ..note::
 


### PR DESCRIPTION
Added missing `request` arg to `render()` example.
