### PR TITLE
django.conf.urls.defaults is deprecated.

### DIFF
--- a/jingo/tests/urls.py
+++ b/jingo/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns
+from django.conf.urls import patterns
 
 
 urlpatterns = patterns('',


### PR DESCRIPTION
See for the related commit: https://github.com/mozilla/kitsune/commit/2ed03c700700778342cf1c411c3b851fd28f9c47
