### PR TITLE
use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
+python: 2.6
 env:
-  - DJANGO_VERSION=1.4.6
-  - DJANGO_VERSION=1.5.2
+  - TOX_ENV=py26-1.4
+  - TOX_ENV=py26-1.5
+  - TOX_ENV=py26-1.6
+  - TOX_ENV=py27-1.4
+  - TOX_ENV=py27-1.5
+  - TOX_ENV=py27-1.6
+  - TOX_ENV=py33-1.5
+  - TOX_ENV=py33-1.6
 install:
-  - pip install Django==${DJANGO_VERSION}
-  - pip install -r requirements.txt
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION=1.4.6
-script: python run_tests.py
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -198,3 +198,8 @@ To run the test suite, you need to define ``DJANGO_SETTINGS_MODULE`` first::
 or simply run::
 
     $ python run_tests.py
+
+To test on all supported versions of Python and Django::
+
+    $ pip install tox
+    $ tox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,3 +182,8 @@ To run the test suite, you need to define ``DJANGO_SETTINGS_MODULE`` first::
 or simply run::
 
     $ python run_tests.py
+
+To test on all supported versions of Python and Django::
+
+    $ pip install tox
+    $ tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,61 @@
+[tox]
+envlist = py26-1.4, py26-1.5, py26-1.6, py27-1.4, py27-1.5, py27-1.6, py33-1.5, py33-1.6
+toxworkdir = {homedir}/.tox-jingo
+
+[testenv]
+commands =
+    python run_tests.py
+deps =
+    sphinx
+    jinja2==2.7
+    nose
+    mock
+
+[testenv:py26-1.4]
+basepython = python2.6
+deps =
+    Django==1.4.10
+    {[testenv]deps}
+
+[testenv:py26-1.5]
+basepython = python2.6
+deps =
+    Django==1.5.5
+    {[testenv]deps}
+
+[testenv:py26-1.6]
+basepython = python2.6
+deps =
+    Django==1.6
+    {[testenv]deps}
+
+[testenv:py27-1.4]
+basepython = python2.7
+deps =
+    Django==1.4.10
+    {[testenv]deps}
+
+
+[testenv:py27-1.5]
+basepython = python2.7
+deps =
+    Django==1.5.5
+    {[testenv]deps}
+
+[testenv:py27-1.6]
+basepython = python2.7
+deps =
+    Django==1.6
+    {[testenv]deps}
+
+[testenv:py33-1.5]
+basepython = python3.3
+deps =
+    Django==1.5.5
+    {[testenv]deps}
+
+[testenv:py33-1.6]
+basepython = python3.3
+deps =
+    Django==1.6
+    {[testenv]deps}


### PR DESCRIPTION
Use tox to make sure the app is tested on all supported versions of Python and Django.

Also, make travis use tox, because it's just simpler, and it makes sure there's no inconsistency between travis and tox builds (and if tox runs fine locally, it should just run as fine on travis: no "fix travis" commits to fiddle with the configuration!)
