### PR TITLE
helpers.f converts input to string before interpolating (bug #53)

### DIFF
--- a/jingo/helpers.py
+++ b/jingo/helpers.py
@@ -31,6 +31,7 @@ def f(string, *args, **kwargs):
     >>> {{ "{0} arguments and {x} arguments"|f('positional', x='keyword') }}
     "positional arguments and keyword arguments"
     """
+    string = six.text_type(string)
     return string.format(*args, **kwargs)
 
 

--- a/jingo/tests/test_helpers.py
+++ b/jingo/tests/test_helpers.py
@@ -24,6 +24,8 @@ def test_f():
     s = render('{{ "{0} : {z}"|f("a", z="b") }}')
     eq_(s, 'a : b')
 
+    s = helpers.f(Markup('this is {0}'), '<b>markup</b>')
+    eq_(s, 'this is <b>markup</b>')
 
 def test_fe_helper():
     context = {'var': '<bad>'}


### PR DESCRIPTION
This fixes issue #53 by first converting ```helpers.f``` input to a string
before interpolating (like it used to do)