### PR TITLE
Fix has_helpers to use proper arguments for 2.7, 3.3 and 3.4

### DIFF
--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -15,26 +15,26 @@ from django.utils.importlib import import_module
 try:
     import importlib.util
     if hasattr(importlib.util, 'find_spec'):  # Py3>=3.4
-        def has_helpers(path):
-            return importlib.util.find_spec('helpers', path) is not None
+        def has_helpers(config):
+            return importlib.util.find_spec('%s.helpers' % config.name) is not None
     else:  # Py3<3.4
-        def has_helpers(path):
+        def has_helpers(config):
             # For Python 3.3, just try to import the module. Unfortunately,
             # this changes the contract slightly for Python 3.3: if there is an
             # module but this raises a legitimate ImportError, jingo will act
             # as if the module doesn't exist. The intent is that we raise
             # legitimate ImportErrors but ignore missing modules.
             try:
-                import_module('helpers', path)
+                import_module('%s.helpers' % config.name)
                 return True
             except ImportError:
                 return False
 except ImportError:
     import imp
 
-    def has_helpers(path):
+    def has_helpers(config):
         try:
-            imp.find_module('helpers', path)
+            imp.find_module('helpers', [config.path])
             return True
         except ImportError:
             return False
@@ -179,7 +179,7 @@ def load_helpers():
     from jingo import helpers  # noqa
 
     for config in apps.get_app_configs():
-        if not has_helpers(config.name):
+        if not has_helpers(config):
             continue
 
         import_module('%s.helpers' % config.name)

--- a/jingo/tests/django_app/helpers.py
+++ b/jingo/tests/django_app/helpers.py
@@ -1,0 +1,6 @@
+from jingo import register
+
+
+@register.filter
+def test_filter(anything):
+    return 'Success!'

--- a/jingo/tests/test_basics.py
+++ b/jingo/tests/test_basics.py
@@ -11,6 +11,8 @@ except ImportError:
 
 import jingo
 
+from .utils import render as render_string
+
 
 @patch('jingo.get_env')
 def test_render(mock_get_env):
@@ -45,3 +47,9 @@ def test_inclusion_tag():
         mock_get_template.return_value = temp
         t = env.from_string('{{ tag(1) }}')
         eq_('<1>', t.render())
+
+
+def test_helpers_loaded():
+    """Test that helpers are loaded correctly."""
+    s = render_string('{{ "something"|test_filter }}', {})
+    eq_('Success!', s)


### PR DESCRIPTION
`imp.find_module` requires a list of actual directory paths to function properly.
