### PR TITLE
Compat for Django 1.9 and 1.10

### DIFF
--- a/fake_settings.py
+++ b/fake_settings.py
@@ -21,3 +21,24 @@ JINGO_EXCLUDE_APPS = ('django_app',)
 ROOT_URLCONF = 'jingo.tests.urls'
 
 SECRET_KEY = 'jingo'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [path('jingo/tests/templates'),],
+        'OPTIONS': {
+            'debug': True,
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'loaders': [
+                'jingo.Loader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ],
+        },
+    },
+]

--- a/fake_settings.py
+++ b/fake_settings.py
@@ -7,6 +7,9 @@ INSTALLED_APPS = (
     'django.contrib.admin.apps.SimpleAdminConfig',
     'jingo.tests.jinja_app',
     'jingo.tests.django_app',
+    'django.contrib.sites',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
 )
 TEMPLATE_LOADERS = (
     'jingo.Loader',

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import functools
 import logging
 import re
+from copy import deepcopy
 
 from django.apps import apps
 from django.conf import settings
@@ -96,7 +97,8 @@ class Template(jinja2.Template):
             context = FakeRequestContext()
 
         # Used by debug_toolbar.
-        if settings.TEMPLATE_DEBUG:
+        TEMPLATES_copy = deepcopy(settings.TEMPLATES)
+        if TEMPLATES_copy[0]['OPTIONS']['debug']:
             from django.test import signals
             self.origin = Origin(self.filename)
             signals.template_rendered.send(sender=self, template=self,

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -239,7 +239,7 @@ register = Register()
 class Loader(BaseLoader):
     is_usable = True
 
-    def __init__(self):
+    def __init__(self, args):
         if has_engine:
             super(Loader, self).__init__(Engine.get_default())
         else:

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -8,7 +8,7 @@ import re
 
 from django.apps import apps
 from django.conf import settings
-from django.template.base import Origin, TemplateDoesNotExist
+from django.template.base import Origin
 from django.template.loader import BaseLoader
 
 try:
@@ -72,6 +72,8 @@ log = logging.getLogger('jingo')
 
 _helpers_loaded = False
 
+class TemplateDoesNotExist(Exception):
+    pass
 
 class Template(jinja2.Template):
 

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -9,7 +9,7 @@ import re
 from django.apps import apps
 from django.conf import settings
 from django.template.base import Origin
-from django.template.loader import BaseLoader
+from django.template.loaders.base import Loader as BaseLoader
 
 try:
     from importlib import import_module

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -10,7 +10,10 @@ from copy import deepcopy
 from django.apps import apps
 from django.conf import settings
 from django.template.base import Origin
-from django.template.loaders.base import Loader as BaseLoader
+try:
+    from django.template.loader import BaseLoader
+except ImportError:
+    from django.template.loaders.base import Loader as BaseLoader
 
 try:
     from importlib import import_module

--- a/jingo/__init__.py
+++ b/jingo/__init__.py
@@ -242,7 +242,7 @@ register = Register()
 class Loader(BaseLoader):
     is_usable = True
 
-    def __init__(self, args):
+    def __init__(self, args=None):
         if has_engine:
             super(Loader, self).__init__(Engine.get_default())
         else:

--- a/jingo/ext.py
+++ b/jingo/ext.py
@@ -10,7 +10,7 @@ except ImportError:
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from django.template.defaulttags import CsrfTokenNode
-from django.utils import six
+import six
 from django.utils.encoding import smart_str
 try:
     from django.utils.encoding import smart_unicode as smart_text

--- a/jingo/monkey.py
+++ b/jingo/monkey.py
@@ -28,15 +28,15 @@ def __html__(self):
 
 
 def patch():
-    from django.forms import forms, formsets, util, widgets
+    from django.forms import forms, formsets, utils, widgets
 
     # Add __html__ methods to these classes:
     classes = [
         forms.BaseForm,
         forms.BoundField,
         formsets.BaseFormSet,
-        util.ErrorDict,
-        util.ErrorList,
+        utils.ErrorDict,
+        utils.ErrorList,
         widgets.Media,
         widgets.RadioFieldRenderer,
     ]

--- a/jingo/monkey.py
+++ b/jingo/monkey.py
@@ -20,7 +20,7 @@ This patch was originally developed by Jeff Balogh.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.utils import six
+import six
 
 
 def __html__(self):

--- a/jingo/tests/test_helpers.py
+++ b/jingo/tests/test_helpers.py
@@ -7,7 +7,7 @@ import cgi
 from datetime import datetime
 from collections import namedtuple
 
-from django.utils import six
+import six
 from jinja2 import Markup
 try:
     from unittest.mock import patch

--- a/jingo/tests/test_monkey.py
+++ b/jingo/tests/test_monkey.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.utils import six
+import six
 
 from jinja2 import escape
 from nose.tools import eq_

--- a/jingo/tests/urls.py
+++ b/jingo/tests/urls.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import patterns
+from django.conf.urls import url
 
 
-urlpatterns = patterns('',
-    (r'^url/(\d+)/(\w+)/$', lambda r: None, {}, "url-args"),
-    (r'^url/(?P<num>\d+)/(?P<word>\w+)/$', lambda r: None, {}, "url-kwargs"),
-)
+urlpatterns = [
+    url(r'^url/(\d+)/(\w+)/$', lambda r: None, {}, "url-args"),
+    url(r'^url/(?P<num>\d+)/(?P<word>\w+)/$', lambda r: None, {}, "url-kwargs"),
+]

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,9 +10,11 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'fake_settings'
 os.environ['PYTHONPATH'] = os.pathsep.join([ROOT,
                                             os.path.join(ROOT, 'examples')])
 
+import django
+if hasattr(django, 'setup'):
+    django.setup()
+
+from django.contrib.contenttypes.models import ContentType
+
 if __name__ == '__main__':
-    if hasattr(django, 'setup'):
-        # Django's app registry was added in 1.7. We need to call `setup` to
-        # initiate it.
-        django.setup()
     nose.main()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=['jingo'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['jinja2'],
+    install_requires=['jinja2', 'six'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-1.7, py27-1.8, py33-1.7, py33-1.8, py34-1.7, py34-1.8
+envlist = py27-1.7, py27-1.8, py27-1.9, py33-1.7, py33-1.8, py34-1.7, py34-1.8, py34-1.9
 toxworkdir = {homedir}/.tox-jingo
 
 [testenv]
@@ -20,6 +20,12 @@ deps =
 basepython = python2.7
 deps =
     Django>=1.8,<1.9
+    {[testenv]deps}
+
+[testenv:py27-1.9]
+basepython = python2.7
+deps =
+    Django>=1.9,<1.10
     {[testenv]deps}
 
 [testenv:py33-1.7]
@@ -44,6 +50,12 @@ deps =
 basepython = python3.4
 deps =
     Django>=1.8,<1.9
+    {[testenv]deps}
+
+[testenv:py34-1.9]
+basepython = python3.4
+deps =
+    Django>=1.9,<1.10
     {[testenv]deps}
 
 [testenv:py35-1.8]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     jinja2
     nose
     mock
+    six
 
 [testenv:py27-1.7]
 basepython = python2.7


### PR DESCRIPTION
Hi there!

I'm the package maintainer of python-jingo in Debian. I maintain it, because it's a build-dependency of python-django-compressor, which is itself used by OpenStack Horizon (the OpenStack dashboard), and I maintain all packages for OpenStack in Debian.

As we're going to ship Debian 9 (aka: Stretch, which we will freeze a the end of the year) with Django 1.10, we are already extensively testing and making sure that all of our packages are Django 1.10 ready. Therefore, we're testing them against the beta1 release of Django (which is currently in Debian Experimental).

I have therefore written a few patches for Jingo to support Django 1.10. As much as I can tell, you guys aren't even supporting Django 1.9, which is already old (more than 6 months). I have rebuilt the package in both Django 1.9 and 1.10 env, and all unit tests are passing. Well, all but:
- test_render_django
- test_render_django_no_toplevel_override
- test_render_django_toplevel_override

I haven't figured out yet how to fix these in Django 1.9 / 1.10, and I'm not much interested in it, because it looks like only fixing the unit tests themselves. However, if you can come with a patch, I'd love to use it.

Best would be if you could release a new version of Jingo with this pull request, plus the fix of the 3 unit tests above which are failing. In such case, please let me know (I'm zigo on Freenode and OFTC), and I'll make sure your new upstream release ends up in Debian Stretch.

Hoping this pull request helps,

Thomas Goirand (zigo)
